### PR TITLE
Fix: use correct logic for node Ready/NotReady status

### DIFF
--- a/kubectl_mcp_tool/mcp_server.py
+++ b/kubectl_mcp_tool/mcp_server.py
@@ -140,7 +140,14 @@ class MCPServer:
                     "nodes": [
                         {
                             "name": node.metadata.name,
-                            "status": node.status.conditions[-1].type if node.status.conditions else None,
+                            "status": (
+                                "Ready"
+                                if any(
+                                    cond.type == "Ready" and cond.status == "True"
+                                    for cond in node.status.conditions
+                                )
+                                else "NotReady"
+                            ),
                             "addresses": [addr.address for addr in node.status.addresses]
                         } for node in nodes.items
                     ]

--- a/kubectl_mcp_tool/mcp_server.py
+++ b/kubectl_mcp_tool/mcp_server.py
@@ -148,9 +148,12 @@ class MCPServer:
                                 )
                                 else "NotReady"
                             ),
-                            "addresses": [addr.address for addr in node.status.addresses]
-                        } for node in nodes.items
-                    ]
+                            "addresses": [
+                                addr.address for addr in node.status.addresses
+                            ],
+                        }
+                        for node in nodes.items
+                    ],
                 }
             except Exception as e:
                 logger.error(f"Error getting nodes: {e}")


### PR DESCRIPTION
The current implementation of `get_nodes()` reports node status using:
```python
node.status.conditions[-1].type
```

I think this is incorrect because:
* The logic checks the `.type` field of the last condition, instead of looking for the `"Ready"` condition specifically.
* Even if the last condition is `"Ready"`, it does **not** check the `.status` field (e.g., "True", "False", or "Unknown").
* As a result, nodes with `"Ready"` condition status `"False"` or `"Unknown"` are still reported as `"Ready"`
   
**Example**
Here is a output from kubectl describe node and kubectl get nodes:
```
Conditions:
  Type             Status    Reason              Message
  ----             ------    ------              -------
  MemoryPressure   Unknown   NodeStatusUnknown   Kubelet stopped posting node status.
  DiskPressure     Unknown   NodeStatusUnknown   Kubelet stopped posting node status.
  PIDPressure      Unknown   NodeStatusUnknown   Kubelet stopped posting node status.
  Ready            Unknown   NodeStatusUnknown   Kubelet stopped posting node status.

NAME                                         STATUS
ip-10-*.{region}.compute.internal  NotReady
```

But the API returns:
```
"status": "Ready"
```
**Fix**
Replace the logic with an explicit check for "Ready" condition status
