### PR TITLE
feat(logging): Add environment-based logger configuration and cleanup logging init

### DIFF
--- a/kubectl_mcp_tool/mcp_server.py
+++ b/kubectl_mcp_tool/mcp_server.py
@@ -11,6 +11,9 @@ import os
 from typing import Dict, Any, List, Optional, Callable, Awaitable
 
 import warnings
+
+from kubectl_mcp_tool.utils.logging_util import set_logger_with_envs
+
 warnings.filterwarnings(
     "ignore",
     category=RuntimeWarning,
@@ -36,8 +39,8 @@ except ImportError:
 from .natural_language import process_query
 
 # Configure logging
-logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger("mcp-server")
+set_logger_with_envs(logger)
 
 class MCPServer:
     """MCP server implementation."""

--- a/kubectl_mcp_tool/utils/logging_util.py
+++ b/kubectl_mcp_tool/utils/logging_util.py
@@ -1,0 +1,42 @@
+import logging
+import os
+import sys
+
+
+def set_logger_with_envs(logger: logging.Logger):
+    """
+    Set the logger with logging related environment variables
+
+    TODO: This is temporary logger setting function. logger setting needs to be organized in the future.
+
+    Args:
+        logger: logger to set with environment variables
+    """
+
+    logger.propagate = False
+
+    # log level setting
+    if os.environ.get("MCP_DEBUG", "").lower() in ("1", "true"):
+        # MCP_DEBUG has higher priority than KUBECTL_MCP_LOG_LEVEL
+        log_level = logging.DEBUG
+    elif log_level_str := os.environ.get("KUBECTL_MCP_LOG_LEVEL"):
+        # log_level_str is "DEBUG", "INFO", "WARNING", or "ERROR"
+        log_level = getattr(logging, log_level_str.upper())
+    else:
+        log_level = logging.INFO
+
+    logger.setLevel(level=log_level)
+
+    # NOTE: some script (e.g. mcp_server.py) loads logger twice when it runs. To prevent duplicate logging.
+    if not logger.handlers:
+        # logger handler setting
+        log_file = os.environ.get("MCP_LOG_FILE")
+        if log_file:
+            os.makedirs(os.path.dirname(log_file), exist_ok=True)
+            handler = logging.FileHandler(log_file)
+        else:
+            handler = logging.StreamHandler(sys.stderr)
+
+        formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(name)s - %(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)


### PR DESCRIPTION
## Description

### Summary
Currently, there is no way applying env vars related to logging when executing kubectl_mcp_tool.mcp_server.
To solve, this, this PR introduces an improved logging configuration for the MCP server by adding a new utility function, `set_logger_with_envs`, in `kubectl_mcp_tool/utils/logging_util.py`.  
This utility enables logging behaviour (log level, output target) to be controlled via environment variables, making the MCP server easier to debug and operate in various environments.


---

### Changes

- **New Utility:**
  - Added `set_logger_with_envs(logger)` in `kubectl_mcp_tool/utils/logging_util.py`
  - Log level set by `MCP_DEBUG` (takes priority) or `KUBECTL_MCP_LOG_LEVEL`
  - Output target can be changed using `MCP_LOG_FILE` (otherwise logs to `stderr`)
  - Prevents duplicate log handlers if logger is initialized multiple times
  - Disables propagation to parent loggers to avoid duplicate output
  - Uses consistent format:  
    ```
    %(asctime)s - %(levelname)s - %(name)s - %(message)s
    ```

- **MCP Server:**
  - Updated to use `set_logger_with_envs(logger)` for configuration
  - Removed direct `basicConfig` usage
---

### Motivation

- **Flexibility:**  
  Logging can be controlled per environment without code changes.
- **Cleaner Startup:**  
  Avoids duplicate log output from multiple initializations.
- **Operational Ease:**  
  Easily redirect logs and adjust levels for debugging or production.
- **Technical Debt:**  
  Moves logger setup into a utility function, preparing for more robust logging improvements.
---

### Test
- local run : python -m kubectl_mcp_tool.mcp_server
- custom mcp client with logging file and logging level setting env variable