### PR TITLE
ci: Fix automatic publishing workflows

### DIFF
--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -3,6 +3,7 @@ name: Build & Publish Multi-Arch Docker Image
 on:
   push:
     branches: [main]
+    tags: ['v*']
   release:
     types: [published]
 
@@ -29,12 +30,23 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: rohitghumare64/kubectl-mcp-server
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+
       - name: Build and push multi-arch image
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: |
-            rohitghumare64/kubectl-mcp-server:latest
-            rohitghumare64/kubectl-mcp-server:${{ github.sha }} 
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }} 

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,6 +1,8 @@
 name: Publish to PyPI
 
 on:
+  push:
+    tags: ['v*']
   release:
     types: [published]
 
@@ -9,18 +11,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: '3.9'
+    
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install build twine
-    - name: Build and publish
+    
+    - name: Extract version from tag
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+    
+    - name: Build package
+      run: python -m build
+    
+    - name: Publish to PyPI
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python -m build
-        twine upload dist/*
+      run: twine upload dist/*


### PR DESCRIPTION
Docker workflow:
- Added tag trigger (v*)
- Use docker/metadata-action for proper version tags
- Tags: latest, version (v1.2.0), major.minor (1.2), sha

PyPI workflow:
- Added tag trigger (v*)
- Now publishes on both tags and releases

After merging, create a tag to trigger publishing:
  git tag v1.2.0
  git push origin v1.2.0