### PR TITLE
feat: Add safety modes (read-only, disable-destructive) for v1.19.0

### DIFF
--- a/kubectl_mcp_tool/cli/output.py
+++ b/kubectl_mcp_tool/cli/output.py
@@ -266,6 +266,7 @@ def format_server_info(
     resource_count: int,
     prompt_count: int,
     context: Optional[str] = None,
+    safety_mode: Optional[Dict[str, Any]] = None,
     as_json: bool = False
 ) -> str:
     info = {
@@ -275,6 +276,9 @@ def format_server_info(
         "prompts": prompt_count,
         "k8s_context": context,
     }
+
+    if safety_mode:
+        info["safety_mode"] = safety_mode
 
     if as_json:
         return json.dumps(info, indent=2)
@@ -290,6 +294,16 @@ def format_server_info(
 
     if context:
         lines.append(f"  {cyan('K8s Context:')} {context}")
+
+    if safety_mode:
+        mode = safety_mode.get("mode", "normal")
+        if mode == "normal":
+            mode_str = green(mode)
+        elif mode == "read_only":
+            mode_str = yellow(mode) + " (write operations blocked)"
+        else:
+            mode_str = yellow(mode) + " (destructive operations blocked)"
+        lines.append(f"  {cyan('Safety Mode:')} {mode_str}")
 
     return "\n".join(lines)
 

--- a/kubectl_mcp_tool/safety.py
+++ b/kubectl_mcp_tool/safety.py
@@ -1,0 +1,155 @@
+"""
+Safety mode implementation for kubectl-mcp-server.
+
+Provides read-only and disable-destructive modes to prevent accidental cluster mutations.
+"""
+
+from enum import Enum
+from functools import wraps
+from typing import Any, Callable, Dict, Set
+import logging
+
+logger = logging.getLogger("mcp-server")
+
+
+class SafetyMode(Enum):
+    """Safety mode levels for the MCP server."""
+    NORMAL = "normal"
+    READ_ONLY = "read_only"
+    DISABLE_DESTRUCTIVE = "disable_destructive"
+
+
+# Global safety mode state
+_current_mode: SafetyMode = SafetyMode.NORMAL
+
+
+# Operations that modify cluster state (blocked in READ_ONLY mode)
+WRITE_OPERATIONS: Set[str] = {
+    # Pod operations
+    "run_pod", "delete_pod",
+    # Deployment operations
+    "scale_deployment", "restart_deployment", "delete_deployment",
+    "rollback_deployment", "create_deployment", "update_deployment",
+    # StatefulSet operations
+    "scale_statefulset", "restart_statefulset", "delete_statefulset",
+    # DaemonSet operations
+    "restart_daemonset", "delete_daemonset",
+    # Service operations
+    "create_service", "delete_service", "update_service",
+    # ConfigMap/Secret operations
+    "create_configmap", "delete_configmap", "update_configmap",
+    "create_secret", "delete_secret", "update_secret",
+    # Namespace operations
+    "create_namespace", "delete_namespace",
+    # Helm operations
+    "install_helm_chart", "upgrade_helm_chart", "uninstall_helm_chart",
+    "rollback_helm_release",
+    # kubectl operations
+    "apply_manifest", "delete_resource", "patch_resource",
+    "create_resource", "replace_resource",
+    # Context operations
+    "switch_context", "set_namespace_for_context",
+    # Rollout operations
+    "rollout_promote_tool", "rollout_abort_tool", "rollout_retry_tool",
+    "rollout_restart_tool",
+    # KubeVirt operations
+    "kubevirt_vm_start_tool", "kubevirt_vm_stop_tool", "kubevirt_vm_restart_tool",
+    "kubevirt_vm_pause_tool", "kubevirt_vm_unpause_tool", "kubevirt_vm_migrate_tool",
+    # CAPI operations
+    "capi_machinedeployment_scale_tool",
+}
+
+# Operations that are destructive (blocked in DISABLE_DESTRUCTIVE mode)
+DESTRUCTIVE_OPERATIONS: Set[str] = {
+    # Delete operations
+    "delete_pod", "delete_deployment", "delete_statefulset", "delete_daemonset",
+    "delete_service", "delete_configmap", "delete_secret", "delete_namespace",
+    "delete_resource",
+    # Helm uninstall
+    "uninstall_helm_chart",
+    # Rollout abort
+    "rollout_abort_tool",
+    # VM stop
+    "kubevirt_vm_stop_tool",
+}
+
+
+def get_safety_mode() -> SafetyMode:
+    """Get the current safety mode."""
+    return _current_mode
+
+
+def set_safety_mode(mode: SafetyMode) -> None:
+    """Set the safety mode globally."""
+    global _current_mode
+    _current_mode = mode
+    logger.info(f"Safety mode set to: {mode.value}")
+
+
+def is_operation_allowed(operation_name: str) -> tuple[bool, str]:
+    """
+    Check if an operation is allowed under the current safety mode.
+
+    Returns:
+        Tuple of (allowed: bool, reason: str)
+    """
+    mode = get_safety_mode()
+
+    if mode == SafetyMode.NORMAL:
+        return True, ""
+
+    if mode == SafetyMode.READ_ONLY:
+        if operation_name in WRITE_OPERATIONS or operation_name in DESTRUCTIVE_OPERATIONS:
+            return False, f"Operation '{operation_name}' blocked: read-only mode is enabled"
+
+    if mode == SafetyMode.DISABLE_DESTRUCTIVE:
+        if operation_name in DESTRUCTIVE_OPERATIONS:
+            return False, f"Operation '{operation_name}' blocked: destructive operations are disabled"
+
+    return True, ""
+
+
+def check_safety_mode(func: Callable) -> Callable:
+    """
+    Decorator to check safety mode before executing a tool function.
+
+    Usage:
+        @check_safety_mode
+        def delete_pod(...):
+            ...
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs) -> Dict[str, Any]:
+        operation_name = func.__name__
+        allowed, reason = is_operation_allowed(operation_name)
+
+        if not allowed:
+            logger.warning(f"Blocked operation: {operation_name} (mode: {get_safety_mode().value})")
+            return {
+                "success": False,
+                "error": reason,
+                "blocked_by": get_safety_mode().value,
+                "operation": operation_name
+            }
+
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def get_mode_info() -> Dict[str, Any]:
+    """Get information about the current safety mode."""
+    mode = get_safety_mode()
+    return {
+        "mode": mode.value,
+        "description": {
+            SafetyMode.NORMAL: "All operations allowed",
+            SafetyMode.READ_ONLY: "Only read operations allowed (no create/update/delete)",
+            SafetyMode.DISABLE_DESTRUCTIVE: "Create/update allowed, delete operations blocked",
+        }[mode],
+        "blocked_operations": {
+            SafetyMode.NORMAL: [],
+            SafetyMode.READ_ONLY: sorted(WRITE_OPERATIONS | DESTRUCTIVE_OPERATIONS),
+            SafetyMode.DISABLE_DESTRUCTIVE: sorted(DESTRUCTIVE_OPERATIONS),
+        }[mode]
+    }

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -1,0 +1,218 @@
+"""Tests for safety mode implementation."""
+
+import pytest
+from kubectl_mcp_tool.safety import (
+    SafetyMode,
+    get_safety_mode,
+    set_safety_mode,
+    is_operation_allowed,
+    check_safety_mode,
+    get_mode_info,
+    WRITE_OPERATIONS,
+    DESTRUCTIVE_OPERATIONS,
+)
+
+
+class TestSafetyMode:
+    """Test safety mode enum and state management."""
+
+    def setup_method(self):
+        """Reset safety mode to NORMAL before each test."""
+        set_safety_mode(SafetyMode.NORMAL)
+
+    def test_default_mode_is_normal(self):
+        """Test that default safety mode is NORMAL."""
+        assert get_safety_mode() == SafetyMode.NORMAL
+
+    def test_set_read_only_mode(self):
+        """Test setting read-only mode."""
+        set_safety_mode(SafetyMode.READ_ONLY)
+        assert get_safety_mode() == SafetyMode.READ_ONLY
+
+    def test_set_disable_destructive_mode(self):
+        """Test setting disable-destructive mode."""
+        set_safety_mode(SafetyMode.DISABLE_DESTRUCTIVE)
+        assert get_safety_mode() == SafetyMode.DISABLE_DESTRUCTIVE
+
+
+class TestOperationAllowed:
+    """Test is_operation_allowed function."""
+
+    def setup_method(self):
+        """Reset safety mode to NORMAL before each test."""
+        set_safety_mode(SafetyMode.NORMAL)
+
+    def test_all_operations_allowed_in_normal_mode(self):
+        """Test that all operations are allowed in NORMAL mode."""
+        for op in WRITE_OPERATIONS | DESTRUCTIVE_OPERATIONS:
+            allowed, reason = is_operation_allowed(op)
+            assert allowed is True
+            assert reason == ""
+
+    def test_read_operations_allowed_in_all_modes(self):
+        """Test that read operations are allowed in all modes."""
+        read_ops = ["get_pods", "list_namespaces", "describe_deployment", "get_logs"]
+
+        for mode in SafetyMode:
+            set_safety_mode(mode)
+            for op in read_ops:
+                allowed, reason = is_operation_allowed(op)
+                assert allowed is True
+
+    def test_write_operations_blocked_in_read_only_mode(self):
+        """Test that write operations are blocked in READ_ONLY mode."""
+        set_safety_mode(SafetyMode.READ_ONLY)
+
+        for op in WRITE_OPERATIONS:
+            allowed, reason = is_operation_allowed(op)
+            assert allowed is False
+            assert "read-only mode" in reason
+
+    def test_destructive_operations_blocked_in_read_only_mode(self):
+        """Test that destructive operations are blocked in READ_ONLY mode."""
+        set_safety_mode(SafetyMode.READ_ONLY)
+
+        for op in DESTRUCTIVE_OPERATIONS:
+            allowed, reason = is_operation_allowed(op)
+            assert allowed is False
+            assert "read-only mode" in reason
+
+    def test_write_operations_allowed_in_disable_destructive_mode(self):
+        """Test that non-destructive write operations are allowed in DISABLE_DESTRUCTIVE mode."""
+        set_safety_mode(SafetyMode.DISABLE_DESTRUCTIVE)
+
+        # Operations that are write but not destructive
+        non_destructive_writes = WRITE_OPERATIONS - DESTRUCTIVE_OPERATIONS
+        for op in non_destructive_writes:
+            allowed, reason = is_operation_allowed(op)
+            assert allowed is True
+
+    def test_destructive_operations_blocked_in_disable_destructive_mode(self):
+        """Test that destructive operations are blocked in DISABLE_DESTRUCTIVE mode."""
+        set_safety_mode(SafetyMode.DISABLE_DESTRUCTIVE)
+
+        for op in DESTRUCTIVE_OPERATIONS:
+            allowed, reason = is_operation_allowed(op)
+            assert allowed is False
+            assert "destructive operations are disabled" in reason
+
+
+class TestCheckSafetyModeDecorator:
+    """Test the check_safety_mode decorator."""
+
+    def setup_method(self):
+        """Reset safety mode to NORMAL before each test."""
+        set_safety_mode(SafetyMode.NORMAL)
+
+    def test_decorator_allows_in_normal_mode(self):
+        """Test that decorated function executes in NORMAL mode."""
+        @check_safety_mode
+        def delete_pod():
+            return {"success": True, "message": "Pod deleted"}
+
+        result = delete_pod()
+        assert result["success"] is True
+        assert result["message"] == "Pod deleted"
+
+    def test_decorator_blocks_write_in_read_only_mode(self):
+        """Test that decorated function is blocked in READ_ONLY mode."""
+        set_safety_mode(SafetyMode.READ_ONLY)
+
+        @check_safety_mode
+        def run_pod():
+            return {"success": True, "message": "Pod created"}
+
+        result = run_pod()
+        assert result["success"] is False
+        assert "blocked" in result["error"]
+        assert result["blocked_by"] == "read_only"
+        assert result["operation"] == "run_pod"
+
+    def test_decorator_blocks_destructive_in_disable_destructive_mode(self):
+        """Test that destructive operations are blocked."""
+        set_safety_mode(SafetyMode.DISABLE_DESTRUCTIVE)
+
+        @check_safety_mode
+        def delete_deployment():
+            return {"success": True, "message": "Deployment deleted"}
+
+        result = delete_deployment()
+        assert result["success"] is False
+        assert "blocked" in result["error"]
+        assert result["blocked_by"] == "disable_destructive"
+
+    def test_decorator_allows_non_destructive_write_in_disable_destructive_mode(self):
+        """Test that non-destructive writes are allowed in DISABLE_DESTRUCTIVE mode."""
+        set_safety_mode(SafetyMode.DISABLE_DESTRUCTIVE)
+
+        @check_safety_mode
+        def scale_deployment():
+            return {"success": True, "message": "Deployment scaled"}
+
+        result = scale_deployment()
+        assert result["success"] is True
+
+
+class TestGetModeInfo:
+    """Test get_mode_info function."""
+
+    def setup_method(self):
+        """Reset safety mode to NORMAL before each test."""
+        set_safety_mode(SafetyMode.NORMAL)
+
+    def test_normal_mode_info(self):
+        """Test mode info in NORMAL mode."""
+        info = get_mode_info()
+        assert info["mode"] == "normal"
+        assert "All operations allowed" in info["description"]
+        assert info["blocked_operations"] == []
+
+    def test_read_only_mode_info(self):
+        """Test mode info in READ_ONLY mode."""
+        set_safety_mode(SafetyMode.READ_ONLY)
+        info = get_mode_info()
+        assert info["mode"] == "read_only"
+        assert "read" in info["description"].lower()
+        assert len(info["blocked_operations"]) > 0
+        assert "delete_pod" in info["blocked_operations"]
+        assert "run_pod" in info["blocked_operations"]
+
+    def test_disable_destructive_mode_info(self):
+        """Test mode info in DISABLE_DESTRUCTIVE mode."""
+        set_safety_mode(SafetyMode.DISABLE_DESTRUCTIVE)
+        info = get_mode_info()
+        assert info["mode"] == "disable_destructive"
+        assert "delete" in info["description"].lower()
+        assert len(info["blocked_operations"]) > 0
+        assert "delete_pod" in info["blocked_operations"]
+        # Non-destructive writes should not be blocked
+        assert "scale_deployment" not in info["blocked_operations"]
+
+
+class TestOperationCategories:
+    """Test that operations are categorized correctly."""
+
+    def test_all_destructive_ops_are_write_ops(self):
+        """Test that all destructive operations are also write operations."""
+        for op in DESTRUCTIVE_OPERATIONS:
+            assert op in WRITE_OPERATIONS, f"{op} is destructive but not in WRITE_OPERATIONS"
+
+    def test_expected_write_operations_exist(self):
+        """Test that expected write operations are defined."""
+        expected = [
+            "run_pod", "delete_pod",
+            "scale_deployment", "restart_deployment",
+            "install_helm_chart", "uninstall_helm_chart",
+            "apply_manifest", "delete_resource",
+        ]
+        for op in expected:
+            assert op in WRITE_OPERATIONS, f"Expected {op} in WRITE_OPERATIONS"
+
+    def test_expected_destructive_operations_exist(self):
+        """Test that expected destructive operations are defined."""
+        expected = [
+            "delete_pod", "delete_deployment", "delete_namespace",
+            "delete_resource", "uninstall_helm_chart",
+        ]
+        for op in expected:
+            assert op in DESTRUCTIVE_OPERATIONS, f"Expected {op} in DESTRUCTIVE_OPERATIONS"


### PR DESCRIPTION
## Summary
- Add `SafetyMode` enum with `NORMAL`, `READ_ONLY`, `DISABLE_DESTRUCTIVE` modes
- Add `WRITE_OPERATIONS` and `DESTRUCTIVE_OPERATIONS` sets to categorize tools
- Implement `check_safety_mode` decorator for blocking operations based on mode
- Add `--read-only` and `--disable-destructive` CLI flags to serve command
- Update `cmd_info` to display current safety mode
- Update `cmd_doctor` to check and report safety mode
- Add 19 comprehensive tests for safety module

## Usage
```bash
# Start server in read-only mode (all write operations blocked)
kubectl-mcp-server serve --read-only

# Start server with only destructive operations blocked
kubectl-mcp-server serve --disable-destructive

# Check current mode
kubectl-mcp-server info
kubectl-mcp-server doctor
```

## Test plan
- [x] Run `pytest tests/test_safety.py -v` - all 19 tests pass
- [ ] Verify --read-only blocks write operations
- [ ] Verify --disable-destructive blocks only delete operations
- [ ] Verify info command shows safety mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safety mode system with three levels: Normal, Read-Only, and Disable-Destructive to control server behavior.
  * New CLI flags `--read-only` and `--disable-destructive` for the serve command to enforce operation restrictions.
  * Server info and health checks now display current safety mode status.

* **Tests**
  * Added comprehensive test suite for safety mode functionality and operation validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->