### PR TITLE
feat: Add OpenTelemetry observability support (v1.20.0)

### DIFF
--- a/kubectl_mcp_tool/observability/__init__.py
+++ b/kubectl_mcp_tool/observability/__init__.py
@@ -1,0 +1,59 @@
+"""
+Observability module for kubectl-mcp-server.
+
+Provides:
+- StatsCollector: Runtime statistics and metrics collection
+- Prometheus metrics: Standard Prometheus format metrics
+- OpenTelemetry tracing: Distributed tracing with OTLP export
+
+Usage:
+    # Stats collection
+    from kubectl_mcp_tool.observability import get_stats_collector
+    stats = get_stats_collector()
+    stats.record_tool_call("get_pods", success=True, duration=0.5)
+
+    # Prometheus metrics
+    from kubectl_mcp_tool.observability import get_metrics
+    metrics_text = get_metrics()
+
+    # Tracing
+    from kubectl_mcp_tool.observability import init_tracing, traced_tool_call
+    init_tracing()
+    with traced_tool_call("get_pods") as span:
+        # execute tool
+        pass
+"""
+
+from .stats import StatsCollector, get_stats_collector
+from .metrics import (
+    get_metrics,
+    record_tool_call_metric,
+    record_tool_error_metric,
+    record_tool_duration_metric,
+    is_prometheus_available,
+)
+from .tracing import (
+    init_tracing,
+    traced_tool_call,
+    get_tracer,
+    is_tracing_available,
+    shutdown_tracing,
+)
+
+__all__ = [
+    # Stats
+    "StatsCollector",
+    "get_stats_collector",
+    # Metrics
+    "get_metrics",
+    "record_tool_call_metric",
+    "record_tool_error_metric",
+    "record_tool_duration_metric",
+    "is_prometheus_available",
+    # Tracing
+    "init_tracing",
+    "traced_tool_call",
+    "get_tracer",
+    "is_tracing_available",
+    "shutdown_tracing",
+]

--- a/kubectl_mcp_tool/observability/metrics.py
+++ b/kubectl_mcp_tool/observability/metrics.py
@@ -1,0 +1,223 @@
+"""
+Prometheus metrics for kubectl-mcp-server.
+
+Provides standard Prometheus format metrics for production monitoring.
+
+Metrics exposed:
+- mcp_tool_calls_total: Counter of tool invocations (labels: tool_name, status)
+- mcp_tool_errors_total: Counter of tool errors (labels: tool_name, error_type)
+- mcp_tool_duration_seconds: Histogram of tool call durations (labels: tool_name)
+- mcp_http_requests_total: Counter of HTTP requests (labels: endpoint, method, status)
+- mcp_server_info: Gauge with server metadata
+
+Requires: prometheus-client>=0.19.0 (optional dependency)
+"""
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Check if prometheus_client is available
+_prometheus_available = False
+_REGISTRY = None
+_tool_calls_counter = None
+_tool_errors_counter = None
+_tool_duration_histogram = None
+_http_requests_counter = None
+_server_info_gauge = None
+
+try:
+    from prometheus_client import (
+        Counter,
+        Histogram,
+        Gauge,
+        CollectorRegistry,
+        generate_latest,
+        CONTENT_TYPE_LATEST,
+    )
+    _prometheus_available = True
+
+    # Create a custom registry to avoid conflicts
+    _REGISTRY = CollectorRegistry()
+
+    # Tool call counter
+    _tool_calls_counter = Counter(
+        "mcp_tool_calls_total",
+        "Total number of MCP tool calls",
+        ["tool_name", "status"],
+        registry=_REGISTRY,
+    )
+
+    # Tool error counter
+    _tool_errors_counter = Counter(
+        "mcp_tool_errors_total",
+        "Total number of MCP tool errors",
+        ["tool_name", "error_type"],
+        registry=_REGISTRY,
+    )
+
+    # Tool duration histogram
+    # Buckets optimized for typical k8s API call durations
+    _tool_duration_histogram = Histogram(
+        "mcp_tool_duration_seconds",
+        "Duration of MCP tool calls in seconds",
+        ["tool_name"],
+        buckets=(0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0),
+        registry=_REGISTRY,
+    )
+
+    # HTTP requests counter
+    _http_requests_counter = Counter(
+        "mcp_http_requests_total",
+        "Total number of HTTP requests",
+        ["endpoint", "method", "status"],
+        registry=_REGISTRY,
+    )
+
+    # Server info gauge (version, features)
+    _server_info_gauge = Gauge(
+        "mcp_server_info",
+        "MCP server information",
+        ["version", "transport"],
+        registry=_REGISTRY,
+    )
+
+    logger.debug("Prometheus metrics initialized successfully")
+
+except ImportError:
+    logger.debug(
+        "prometheus_client not installed. Prometheus metrics disabled. "
+        "Install with: pip install kubectl-mcp-server[observability]"
+    )
+
+
+def is_prometheus_available() -> bool:
+    """Check if Prometheus client is available."""
+    return _prometheus_available
+
+
+def record_tool_call_metric(
+    tool_name: str,
+    success: bool = True,
+    duration: float = 0.0
+) -> None:
+    """
+    Record a tool call in Prometheus metrics.
+
+    Args:
+        tool_name: Name of the tool called
+        success: Whether the call succeeded
+        duration: Call duration in seconds
+    """
+    if not _prometheus_available:
+        return
+
+    status = "success" if success else "error"
+    _tool_calls_counter.labels(tool_name=tool_name, status=status).inc()
+
+    if duration > 0:
+        _tool_duration_histogram.labels(tool_name=tool_name).observe(duration)
+
+
+def record_tool_error_metric(
+    tool_name: str,
+    error_type: str = "unknown"
+) -> None:
+    """
+    Record a tool error in Prometheus metrics.
+
+    Args:
+        tool_name: Name of the tool that errored
+        error_type: Type/category of error (e.g., "timeout", "validation", "k8s_api")
+    """
+    if not _prometheus_available:
+        return
+
+    _tool_errors_counter.labels(
+        tool_name=tool_name,
+        error_type=error_type
+    ).inc()
+
+
+def record_tool_duration_metric(tool_name: str, duration: float) -> None:
+    """
+    Record tool duration in Prometheus histogram.
+
+    Args:
+        tool_name: Name of the tool
+        duration: Duration in seconds
+    """
+    if not _prometheus_available:
+        return
+
+    _tool_duration_histogram.labels(tool_name=tool_name).observe(duration)
+
+
+def record_http_request_metric(
+    endpoint: str,
+    method: str,
+    status: int = 200
+) -> None:
+    """
+    Record an HTTP request in Prometheus metrics.
+
+    Args:
+        endpoint: Request endpoint path
+        method: HTTP method
+        status: HTTP status code
+    """
+    if not _prometheus_available:
+        return
+
+    _http_requests_counter.labels(
+        endpoint=endpoint,
+        method=method,
+        status=str(status)
+    ).inc()
+
+
+def set_server_info(version: str, transport: str) -> None:
+    """
+    Set server info in Prometheus gauge.
+
+    Args:
+        version: Server version
+        transport: Transport type (stdio, sse, http)
+    """
+    if not _prometheus_available:
+        return
+
+    _server_info_gauge.labels(version=version, transport=transport).set(1)
+
+
+def get_metrics() -> str:
+    """
+    Get metrics in Prometheus text format.
+
+    Returns:
+        Prometheus metrics as text, or error message if unavailable
+    """
+    if not _prometheus_available:
+        return (
+            "# Prometheus metrics not available.\n"
+            "# Install with: pip install kubectl-mcp-server[observability]\n"
+        )
+
+    try:
+        return generate_latest(_REGISTRY).decode("utf-8")
+    except Exception as e:
+        logger.error(f"Error generating Prometheus metrics: {e}")
+        return f"# Error generating metrics: {e}\n"
+
+
+def get_metrics_content_type() -> str:
+    """
+    Get the content type for Prometheus metrics.
+
+    Returns:
+        Prometheus content type string
+    """
+    if not _prometheus_available:
+        return "text/plain; charset=utf-8"
+    return CONTENT_TYPE_LATEST

--- a/kubectl_mcp_tool/observability/stats.py
+++ b/kubectl_mcp_tool/observability/stats.py
@@ -1,0 +1,255 @@
+"""
+Runtime statistics collection for kubectl-mcp-server.
+
+Provides a singleton StatsCollector that tracks:
+- tool_calls_total: Total number of tool invocations
+- tool_errors_total: Total number of tool errors
+- tool_calls_by_name: Breakdown of calls by tool name
+- http_requests_total: Total HTTP requests (for SSE/HTTP transports)
+- uptime: Server uptime in seconds
+"""
+
+import time
+import threading
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Dict, Any, Optional
+
+
+@dataclass
+class ToolStats:
+    """Statistics for a single tool."""
+    calls: int = 0
+    errors: int = 0
+    total_duration: float = 0.0
+    last_call_time: Optional[float] = None
+    last_error_time: Optional[float] = None
+
+
+class StatsCollector:
+    """
+    Singleton class for collecting runtime statistics.
+
+    Thread-safe statistics collection for production observability.
+
+    Usage:
+        stats = get_stats_collector()
+        stats.record_tool_call("get_pods", success=True, duration=0.5)
+
+        # Get current stats
+        data = stats.get_stats()
+    """
+
+    _instance: Optional["StatsCollector"] = None
+    _lock = threading.Lock()
+
+    def __new__(cls) -> "StatsCollector":
+        """Ensure singleton pattern."""
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
+                    cls._instance._initialized = False
+        return cls._instance
+
+    def __init__(self):
+        """Initialize the stats collector (only once)."""
+        if self._initialized:
+            return
+
+        self._stats_lock = threading.Lock()
+        self._start_time = time.time()
+
+        # Core counters
+        self._tool_calls_total = 0
+        self._tool_errors_total = 0
+        self._http_requests_total = 0
+
+        # Per-tool statistics
+        self._tool_stats: Dict[str, ToolStats] = defaultdict(ToolStats)
+
+        # HTTP request breakdown
+        self._http_requests_by_endpoint: Dict[str, int] = defaultdict(int)
+        self._http_requests_by_method: Dict[str, int] = defaultdict(int)
+
+        self._initialized = True
+
+    def record_tool_call(
+        self,
+        tool_name: str,
+        success: bool = True,
+        duration: float = 0.0
+    ) -> None:
+        """
+        Record a tool call.
+
+        Args:
+            tool_name: Name of the tool that was called
+            success: Whether the call succeeded
+            duration: Call duration in seconds
+        """
+        with self._stats_lock:
+            self._tool_calls_total += 1
+
+            stats = self._tool_stats[tool_name]
+            stats.calls += 1
+            stats.total_duration += duration
+            stats.last_call_time = time.time()
+
+            if not success:
+                self._tool_errors_total += 1
+                stats.errors += 1
+                stats.last_error_time = time.time()
+
+    def record_tool_error(self, tool_name: str) -> None:
+        """
+        Record a tool error (shorthand for failed call).
+
+        Args:
+            tool_name: Name of the tool that errored
+        """
+        self.record_tool_call(tool_name, success=False)
+
+    def record_http_request(
+        self,
+        endpoint: str = "/",
+        method: str = "POST"
+    ) -> None:
+        """
+        Record an HTTP request.
+
+        Args:
+            endpoint: Request endpoint path
+            method: HTTP method (GET, POST, etc.)
+        """
+        with self._stats_lock:
+            self._http_requests_total += 1
+            self._http_requests_by_endpoint[endpoint] += 1
+            self._http_requests_by_method[method] += 1
+
+    @property
+    def uptime(self) -> float:
+        """Get server uptime in seconds."""
+        return time.time() - self._start_time
+
+    @property
+    def tool_calls_total(self) -> int:
+        """Get total tool calls."""
+        with self._stats_lock:
+            return self._tool_calls_total
+
+    @property
+    def tool_errors_total(self) -> int:
+        """Get total tool errors."""
+        with self._stats_lock:
+            return self._tool_errors_total
+
+    @property
+    def http_requests_total(self) -> int:
+        """Get total HTTP requests."""
+        with self._stats_lock:
+            return self._http_requests_total
+
+    def get_tool_stats(self, tool_name: str) -> Optional[Dict[str, Any]]:
+        """
+        Get statistics for a specific tool.
+
+        Args:
+            tool_name: Name of the tool
+
+        Returns:
+            Dictionary with tool statistics or None if not found
+        """
+        with self._stats_lock:
+            if tool_name not in self._tool_stats:
+                return None
+
+            stats = self._tool_stats[tool_name]
+            avg_duration = (
+                stats.total_duration / stats.calls
+                if stats.calls > 0 else 0.0
+            )
+
+            return {
+                "calls": stats.calls,
+                "errors": stats.errors,
+                "error_rate": stats.errors / stats.calls if stats.calls > 0 else 0.0,
+                "total_duration_seconds": stats.total_duration,
+                "average_duration_seconds": avg_duration,
+                "last_call_time": stats.last_call_time,
+                "last_error_time": stats.last_error_time,
+            }
+
+    def get_stats(self) -> Dict[str, Any]:
+        """
+        Get all statistics as a JSON-serializable dictionary.
+
+        Returns:
+            Dictionary containing all collected statistics
+        """
+        with self._stats_lock:
+            # Calculate tool-level stats
+            tool_stats_dict = {}
+            for tool_name, stats in self._tool_stats.items():
+                avg_duration = (
+                    stats.total_duration / stats.calls
+                    if stats.calls > 0 else 0.0
+                )
+                tool_stats_dict[tool_name] = {
+                    "calls": stats.calls,
+                    "errors": stats.errors,
+                    "error_rate": stats.errors / stats.calls if stats.calls > 0 else 0.0,
+                    "average_duration_seconds": round(avg_duration, 4),
+                }
+
+            # Sort tools by call count (descending)
+            sorted_tools = dict(
+                sorted(
+                    tool_stats_dict.items(),
+                    key=lambda x: x[1]["calls"],
+                    reverse=True
+                )
+            )
+
+            return {
+                "uptime_seconds": round(self.uptime, 2),
+                "tool_calls_total": self._tool_calls_total,
+                "tool_errors_total": self._tool_errors_total,
+                "tool_error_rate": (
+                    self._tool_errors_total / self._tool_calls_total
+                    if self._tool_calls_total > 0 else 0.0
+                ),
+                "http_requests_total": self._http_requests_total,
+                "http_requests_by_endpoint": dict(self._http_requests_by_endpoint),
+                "http_requests_by_method": dict(self._http_requests_by_method),
+                "tool_calls_by_name": sorted_tools,
+                "unique_tools_called": len(self._tool_stats),
+            }
+
+    def reset(self) -> None:
+        """Reset all statistics (useful for testing)."""
+        with self._stats_lock:
+            self._start_time = time.time()
+            self._tool_calls_total = 0
+            self._tool_errors_total = 0
+            self._http_requests_total = 0
+            self._tool_stats.clear()
+            self._http_requests_by_endpoint.clear()
+            self._http_requests_by_method.clear()
+
+
+# Module-level singleton accessor
+_stats_collector: Optional[StatsCollector] = None
+
+
+def get_stats_collector() -> StatsCollector:
+    """
+    Get the singleton StatsCollector instance.
+
+    Returns:
+        The global StatsCollector instance
+    """
+    global _stats_collector
+    if _stats_collector is None:
+        _stats_collector = StatsCollector()
+    return _stats_collector

--- a/kubectl_mcp_tool/observability/tracing.py
+++ b/kubectl_mcp_tool/observability/tracing.py
@@ -1,0 +1,335 @@
+"""
+OpenTelemetry tracing for kubectl-mcp-server.
+
+Provides distributed tracing with OTLP export for production observability.
+
+Environment Variables:
+    OTEL_EXPORTER_OTLP_ENDPOINT: OTLP endpoint URL (e.g., http://localhost:4317)
+    OTEL_EXPORTER_OTLP_HEADERS: Optional headers for OTLP exporter
+    OTEL_TRACES_SAMPLER: Sampler type (always_on, always_off, traceidratio, parentbased_always_on)
+    OTEL_TRACES_SAMPLER_ARG: Sampler argument (e.g., 0.5 for 50% sampling)
+    OTEL_SERVICE_NAME: Service name (default: kubectl-mcp-server)
+    OTEL_RESOURCE_ATTRIBUTES: Additional resource attributes
+
+Requires: opentelemetry-api, opentelemetry-sdk, opentelemetry-exporter-otlp (optional dependencies)
+"""
+
+import os
+import logging
+from contextlib import contextmanager
+from typing import Optional, Generator, Any, Dict
+
+logger = logging.getLogger(__name__)
+
+# Check if OpenTelemetry is available
+_otel_available = False
+_tracer = None
+_tracer_provider = None
+
+try:
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider, Span
+    from opentelemetry.sdk.trace.export import (
+        BatchSpanProcessor,
+        ConsoleSpanExporter,
+    )
+    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+    from opentelemetry.trace import Status, StatusCode
+    from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+    _otel_available = True
+    logger.debug("OpenTelemetry tracing modules available")
+
+except ImportError:
+    logger.debug(
+        "OpenTelemetry not installed. Tracing disabled. "
+        "Install with: pip install kubectl-mcp-server[observability]"
+    )
+
+
+def is_tracing_available() -> bool:
+    """Check if OpenTelemetry tracing is available."""
+    return _otel_available
+
+
+def _get_sampler():
+    """
+    Get the configured sampler based on environment variables.
+
+    Supports:
+    - always_on: Always sample
+    - always_off: Never sample
+    - traceidratio: Sample based on ratio (OTEL_TRACES_SAMPLER_ARG)
+    - parentbased_always_on: Parent-based with always_on default
+    """
+    if not _otel_available:
+        return None
+
+    from opentelemetry.sdk.trace.sampling import (
+        ALWAYS_ON,
+        ALWAYS_OFF,
+        TraceIdRatioBased,
+        ParentBasedTraceIdRatio,
+    )
+
+    sampler_type = os.environ.get("OTEL_TRACES_SAMPLER", "parentbased_always_on").lower()
+    sampler_arg = os.environ.get("OTEL_TRACES_SAMPLER_ARG", "1.0")
+
+    try:
+        ratio = float(sampler_arg)
+    except ValueError:
+        ratio = 1.0
+        logger.warning(f"Invalid OTEL_TRACES_SAMPLER_ARG: {sampler_arg}, using 1.0")
+
+    if sampler_type == "always_on":
+        return ALWAYS_ON
+    elif sampler_type == "always_off":
+        return ALWAYS_OFF
+    elif sampler_type == "traceidratio":
+        return TraceIdRatioBased(ratio)
+    elif sampler_type in ("parentbased_always_on", "parentbased_traceidratio"):
+        return ParentBasedTraceIdRatio(ratio)
+    else:
+        logger.warning(f"Unknown sampler type: {sampler_type}, using parentbased_always_on")
+        return ParentBasedTraceIdRatio(ratio)
+
+
+def init_tracing(
+    service_name: Optional[str] = None,
+    service_version: Optional[str] = None,
+) -> bool:
+    """
+    Initialize OpenTelemetry tracing.
+
+    Args:
+        service_name: Service name (default from OTEL_SERVICE_NAME or kubectl-mcp-server)
+        service_version: Service version (default from package version)
+
+    Returns:
+        True if tracing was initialized, False otherwise
+    """
+    global _tracer, _tracer_provider
+
+    if not _otel_available:
+        logger.debug("OpenTelemetry not available, skipping tracing init")
+        return False
+
+    # Already initialized
+    if _tracer is not None:
+        return True
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+        from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+
+        # Get service name
+        if service_name is None:
+            service_name = os.environ.get("OTEL_SERVICE_NAME", "kubectl-mcp-server")
+
+        # Get service version
+        if service_version is None:
+            try:
+                from kubectl_mcp_tool import __version__
+                service_version = __version__
+            except ImportError:
+                service_version = "unknown"
+
+        # Parse additional resource attributes
+        resource_attrs = {
+            SERVICE_NAME: service_name,
+            "service.version": service_version,
+        }
+
+        # Add custom attributes from environment
+        custom_attrs = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
+        if custom_attrs:
+            for attr in custom_attrs.split(","):
+                if "=" in attr:
+                    key, value = attr.split("=", 1)
+                    resource_attrs[key.strip()] = value.strip()
+
+        # Create resource
+        resource = Resource.create(resource_attrs)
+
+        # Create tracer provider with sampler
+        sampler = _get_sampler()
+        _tracer_provider = TracerProvider(resource=resource, sampler=sampler)
+
+        # Add exporter based on environment
+        otlp_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+
+        if otlp_endpoint:
+            # Use OTLP exporter
+            try:
+                from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
+                otlp_headers = os.environ.get("OTEL_EXPORTER_OTLP_HEADERS", "")
+                headers_dict = {}
+                if otlp_headers:
+                    for header in otlp_headers.split(","):
+                        if "=" in header:
+                            key, value = header.split("=", 1)
+                            headers_dict[key.strip()] = value.strip()
+
+                exporter = OTLPSpanExporter(
+                    endpoint=otlp_endpoint,
+                    headers=headers_dict if headers_dict else None,
+                )
+                _tracer_provider.add_span_processor(BatchSpanProcessor(exporter))
+                logger.info(f"OpenTelemetry OTLP exporter configured: {otlp_endpoint}")
+
+            except ImportError:
+                # Try HTTP exporter as fallback
+                try:
+                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter as HTTPOTLPSpanExporter
+
+                    exporter = HTTPOTLPSpanExporter(endpoint=f"{otlp_endpoint}/v1/traces")
+                    _tracer_provider.add_span_processor(BatchSpanProcessor(exporter))
+                    logger.info(f"OpenTelemetry HTTP OTLP exporter configured: {otlp_endpoint}")
+
+                except ImportError:
+                    logger.warning(
+                        "OTLP exporter not available. "
+                        "Install with: pip install opentelemetry-exporter-otlp"
+                    )
+                    # Fall back to console exporter for debugging
+                    from opentelemetry.sdk.trace.export import ConsoleSpanExporter
+                    _tracer_provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+                    logger.info("Using console span exporter (OTLP exporter not available)")
+
+        elif os.environ.get("OTEL_TRACES_EXPORTER") == "console":
+            # Explicitly use console exporter
+            from opentelemetry.sdk.trace.export import ConsoleSpanExporter
+            _tracer_provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+            logger.info("Using console span exporter")
+        else:
+            # No exporter configured, log a message
+            logger.debug(
+                "No OTEL_EXPORTER_OTLP_ENDPOINT set, tracing spans will not be exported. "
+                "Set OTEL_TRACES_EXPORTER=console for debug output."
+            )
+
+        # Set the global tracer provider
+        trace.set_tracer_provider(_tracer_provider)
+
+        # Create tracer
+        _tracer = trace.get_tracer(
+            "kubectl-mcp-server",
+            service_version,
+        )
+
+        logger.info(f"OpenTelemetry tracing initialized for {service_name} v{service_version}")
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to initialize OpenTelemetry tracing: {e}")
+        return False
+
+
+def get_tracer():
+    """
+    Get the OpenTelemetry tracer.
+
+    Returns:
+        The tracer instance, or None if not initialized
+    """
+    return _tracer
+
+
+def shutdown_tracing() -> None:
+    """Shutdown the tracer provider and flush any pending spans."""
+    global _tracer, _tracer_provider
+
+    if _tracer_provider is not None:
+        try:
+            _tracer_provider.shutdown()
+            logger.debug("OpenTelemetry tracing shut down")
+        except Exception as e:
+            logger.error(f"Error shutting down tracing: {e}")
+
+    _tracer = None
+    _tracer_provider = None
+
+
+@contextmanager
+def traced_tool_call(
+    tool_name: str,
+    attributes: Optional[Dict[str, Any]] = None,
+) -> Generator[Any, None, None]:
+    """
+    Context manager for tracing a tool call.
+
+    Creates a span for the tool call and records attributes and errors.
+
+    Args:
+        tool_name: Name of the tool being called
+        attributes: Optional additional span attributes
+
+    Yields:
+        The span object (or a no-op if tracing is disabled)
+
+    Example:
+        with traced_tool_call("get_pods", {"namespace": "default"}) as span:
+            result = await get_pods(namespace="default")
+            span.set_attribute("pod_count", len(result))
+    """
+    if not _otel_available or _tracer is None:
+        # Return a no-op context
+        yield None
+        return
+
+    from opentelemetry.trace import Status, StatusCode
+
+    with _tracer.start_as_current_span(
+        f"mcp.tool.{tool_name}",
+        kind=trace.SpanKind.INTERNAL,
+    ) as span:
+        # Set base attributes
+        span.set_attribute("mcp.tool.name", tool_name)
+
+        # Set additional attributes
+        if attributes:
+            for key, value in attributes.items():
+                if isinstance(value, (str, int, float, bool)):
+                    span.set_attribute(f"mcp.tool.{key}", value)
+
+        try:
+            yield span
+            span.set_status(Status(StatusCode.OK))
+        except Exception as e:
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            span.record_exception(e)
+            raise
+
+
+def add_span_attribute(key: str, value: Any) -> None:
+    """
+    Add an attribute to the current span.
+
+    Args:
+        key: Attribute key
+        value: Attribute value (must be str, int, float, or bool)
+    """
+    if not _otel_available:
+        return
+
+    span = trace.get_current_span()
+    if span is not None and isinstance(value, (str, int, float, bool)):
+        span.set_attribute(key, value)
+
+
+def record_span_exception(exception: Exception) -> None:
+    """
+    Record an exception on the current span.
+
+    Args:
+        exception: The exception to record
+    """
+    if not _otel_available:
+        return
+
+    span = trace.get_current_span()
+    if span is not None:
+        span.record_exception(exception)

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,521 @@
+"""Unit tests for the observability module."""
+
+import pytest
+import time
+import threading
+from unittest.mock import patch, MagicMock
+
+
+class TestStatsCollector:
+    """Tests for StatsCollector class."""
+
+    @pytest.mark.unit
+    def test_singleton_pattern(self):
+        """Test that StatsCollector is a singleton."""
+        from kubectl_mcp_tool.observability.stats import StatsCollector
+
+        instance1 = StatsCollector()
+        instance2 = StatsCollector()
+
+        assert instance1 is instance2
+
+    @pytest.mark.unit
+    def test_get_stats_collector(self):
+        """Test get_stats_collector function."""
+        from kubectl_mcp_tool.observability.stats import get_stats_collector
+
+        collector = get_stats_collector()
+        assert collector is not None
+
+        # Should return same instance
+        collector2 = get_stats_collector()
+        assert collector is collector2
+
+    @pytest.mark.unit
+    def test_record_tool_call_success(self):
+        """Test recording a successful tool call."""
+        from kubectl_mcp_tool.observability.stats import get_stats_collector
+
+        collector = get_stats_collector()
+        collector.reset()
+
+        collector.record_tool_call("test_tool", success=True, duration=0.5)
+
+        assert collector.tool_calls_total == 1
+        assert collector.tool_errors_total == 0
+
+        stats = collector.get_tool_stats("test_tool")
+        assert stats["calls"] == 1
+        assert stats["errors"] == 0
+        assert stats["total_duration_seconds"] == 0.5
+
+    @pytest.mark.unit
+    def test_record_tool_call_error(self):
+        """Test recording a failed tool call."""
+        from kubectl_mcp_tool.observability.stats import get_stats_collector
+
+        collector = get_stats_collector()
+        collector.reset()
+
+        collector.record_tool_call("test_tool", success=False, duration=0.1)
+
+        assert collector.tool_calls_total == 1
+        assert collector.tool_errors_total == 1
+
+        stats = collector.get_tool_stats("test_tool")
+        assert stats["calls"] == 1
+        assert stats["errors"] == 1
+        assert stats["error_rate"] == 1.0
+
+    @pytest.mark.unit
+    def test_record_tool_error(self):
+        """Test record_tool_error shorthand."""
+        from kubectl_mcp_tool.observability.stats import get_stats_collector
+
+        collector = get_stats_collector()
+        collector.reset()
+
+        collector.record_tool_error("error_tool")
+
+        assert collector.tool_calls_total == 1
+        assert collector.tool_errors_total == 1
+
+    @pytest.mark.unit
+    def test_record_http_request(self):
+        """Test recording HTTP requests."""
+        from kubectl_mcp_tool.observability.stats import get_stats_collector
+
+        collector = get_stats_collector()
+        collector.reset()
+
+        collector.record_http_request("/stats", "GET")
+        collector.record_http_request("/metrics", "GET")
+        collector.record_http_request("/mcp", "POST")
+
+        assert collector.http_requests_total == 3
+
+        stats = collector.get_stats()
+        assert stats["http_requests_by_endpoint"]["/stats"] == 1
+        assert stats["http_requests_by_endpoint"]["/metrics"] == 1
+        assert stats["http_requests_by_endpoint"]["/mcp"] == 1
+        assert stats["http_requests_by_method"]["GET"] == 2
+        assert stats["http_requests_by_method"]["POST"] == 1
+
+    @pytest.mark.unit
+    def test_uptime(self):
+        """Test uptime property."""
+        from kubectl_mcp_tool.observability.stats import get_stats_collector
+
+        collector = get_stats_collector()
+        collector.reset()
+
+        time.sleep(0.1)
+        uptime = collector.uptime
+
+        assert uptime >= 0.1
+        assert uptime < 1.0
+
+    @pytest.mark.unit
+    def test_get_stats(self):
+        """Test get_stats returns complete statistics."""
+        from kubectl_mcp_tool.observability.stats import get_stats_collector
+
+        collector = get_stats_collector()
+        collector.reset()
+
+        collector.record_tool_call("tool_a", success=True, duration=0.1)
+        collector.record_tool_call("tool_a", success=True, duration=0.2)
+        collector.record_tool_call("tool_b", success=False, duration=0.3)
+
+        stats = collector.get_stats()
+
+        assert "uptime_seconds" in stats
+        assert stats["tool_calls_total"] == 3
+        assert stats["tool_errors_total"] == 1
+        assert stats["unique_tools_called"] == 2
+        assert "tool_calls_by_name" in stats
+        assert "tool_a" in stats["tool_calls_by_name"]
+        assert "tool_b" in stats["tool_calls_by_name"]
+
+    @pytest.mark.unit
+    def test_get_tool_stats_nonexistent(self):
+        """Test get_tool_stats returns None for nonexistent tool."""
+        from kubectl_mcp_tool.observability.stats import get_stats_collector
+
+        collector = get_stats_collector()
+        collector.reset()
+
+        stats = collector.get_tool_stats("nonexistent_tool")
+        assert stats is None
+
+    @pytest.mark.unit
+    def test_reset(self):
+        """Test reset clears all statistics."""
+        from kubectl_mcp_tool.observability.stats import get_stats_collector
+
+        collector = get_stats_collector()
+
+        collector.record_tool_call("test_tool", success=True)
+        collector.record_http_request("/test", "GET")
+
+        collector.reset()
+
+        assert collector.tool_calls_total == 0
+        assert collector.tool_errors_total == 0
+        assert collector.http_requests_total == 0
+
+    @pytest.mark.unit
+    def test_thread_safety(self):
+        """Test that StatsCollector is thread-safe."""
+        from kubectl_mcp_tool.observability.stats import get_stats_collector
+
+        collector = get_stats_collector()
+        collector.reset()
+
+        def record_calls():
+            for i in range(100):
+                collector.record_tool_call(f"tool_{i % 10}", success=True)
+
+        threads = [threading.Thread(target=record_calls) for _ in range(10)]
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert collector.tool_calls_total == 1000
+
+
+class TestPrometheusMetrics:
+    """Tests for Prometheus metrics module."""
+
+    @pytest.mark.unit
+    def test_is_prometheus_available(self):
+        """Test is_prometheus_available function."""
+        from kubectl_mcp_tool.observability.metrics import is_prometheus_available
+
+        # Should return bool regardless of prometheus_client installation
+        result = is_prometheus_available()
+        assert isinstance(result, bool)
+
+    @pytest.mark.unit
+    def test_get_metrics(self):
+        """Test get_metrics returns Prometheus format."""
+        from kubectl_mcp_tool.observability.metrics import get_metrics, is_prometheus_available
+
+        metrics = get_metrics()
+
+        assert isinstance(metrics, str)
+
+        if is_prometheus_available():
+            # Should have some metric content
+            assert len(metrics) > 0
+        else:
+            # Should return informative message
+            assert "not available" in metrics
+
+    @pytest.mark.unit
+    def test_record_tool_call_metric(self):
+        """Test record_tool_call_metric function."""
+        from kubectl_mcp_tool.observability.metrics import (
+            record_tool_call_metric,
+            is_prometheus_available,
+        )
+
+        # Should not raise even if prometheus_client is not installed
+        record_tool_call_metric("test_tool", success=True, duration=0.5)
+        record_tool_call_metric("test_tool", success=False, duration=0.1)
+
+    @pytest.mark.unit
+    def test_record_tool_error_metric(self):
+        """Test record_tool_error_metric function."""
+        from kubectl_mcp_tool.observability.metrics import record_tool_error_metric
+
+        # Should not raise even if prometheus_client is not installed
+        record_tool_error_metric("test_tool", error_type="validation")
+        record_tool_error_metric("test_tool", error_type="timeout")
+
+    @pytest.mark.unit
+    def test_record_tool_duration_metric(self):
+        """Test record_tool_duration_metric function."""
+        from kubectl_mcp_tool.observability.metrics import record_tool_duration_metric
+
+        # Should not raise even if prometheus_client is not installed
+        record_tool_duration_metric("test_tool", 0.5)
+        record_tool_duration_metric("test_tool", 1.5)
+
+    @pytest.mark.unit
+    def test_record_http_request_metric(self):
+        """Test record_http_request_metric function."""
+        from kubectl_mcp_tool.observability.metrics import record_http_request_metric
+
+        # Should not raise even if prometheus_client is not installed
+        record_http_request_metric("/stats", "GET", 200)
+        record_http_request_metric("/metrics", "GET", 500)
+
+    @pytest.mark.unit
+    def test_set_server_info(self):
+        """Test set_server_info function."""
+        from kubectl_mcp_tool.observability.metrics import set_server_info
+
+        # Should not raise even if prometheus_client is not installed
+        set_server_info("1.16.0", "stdio")
+
+    @pytest.mark.unit
+    def test_get_metrics_content_type(self):
+        """Test get_metrics_content_type function."""
+        from kubectl_mcp_tool.observability.metrics import get_metrics_content_type
+
+        content_type = get_metrics_content_type()
+        assert isinstance(content_type, str)
+        assert "text" in content_type
+
+
+class TestTracing:
+    """Tests for OpenTelemetry tracing module."""
+
+    @pytest.mark.unit
+    def test_is_tracing_available(self):
+        """Test is_tracing_available function."""
+        from kubectl_mcp_tool.observability.tracing import is_tracing_available
+
+        # Should return bool regardless of opentelemetry installation
+        result = is_tracing_available()
+        assert isinstance(result, bool)
+
+    @pytest.mark.unit
+    def test_get_tracer_before_init(self):
+        """Test get_tracer returns None before initialization."""
+        from kubectl_mcp_tool.observability.tracing import get_tracer, shutdown_tracing
+
+        # Ensure clean state
+        shutdown_tracing()
+
+        tracer = get_tracer()
+        # May be None if not initialized, or a tracer if previously initialized
+        # Just verify it doesn't raise
+
+    @pytest.mark.unit
+    def test_traced_tool_call_no_op(self):
+        """Test traced_tool_call works as no-op when tracing unavailable."""
+        from kubectl_mcp_tool.observability.tracing import traced_tool_call, shutdown_tracing
+
+        shutdown_tracing()
+
+        with traced_tool_call("test_tool", {"key": "value"}) as span:
+            # Should work without raising
+            result = 1 + 1
+
+        assert result == 2
+
+    @pytest.mark.unit
+    def test_traced_tool_call_with_exception(self):
+        """Test traced_tool_call propagates exceptions."""
+        from kubectl_mcp_tool.observability.tracing import traced_tool_call
+
+        with pytest.raises(ValueError, match="test error"):
+            with traced_tool_call("test_tool") as span:
+                raise ValueError("test error")
+
+    @pytest.mark.unit
+    def test_add_span_attribute(self):
+        """Test add_span_attribute function."""
+        from kubectl_mcp_tool.observability.tracing import add_span_attribute
+
+        # Should not raise even if tracing is not available
+        add_span_attribute("test_key", "test_value")
+        add_span_attribute("test_int", 42)
+        add_span_attribute("test_float", 3.14)
+        add_span_attribute("test_bool", True)
+
+    @pytest.mark.unit
+    def test_record_span_exception(self):
+        """Test record_span_exception function."""
+        from kubectl_mcp_tool.observability.tracing import record_span_exception
+
+        # Should not raise even if tracing is not available
+        record_span_exception(ValueError("test error"))
+
+    @pytest.mark.unit
+    def test_shutdown_tracing(self):
+        """Test shutdown_tracing function."""
+        from kubectl_mcp_tool.observability.tracing import shutdown_tracing
+
+        # Should not raise even if tracing was not initialized
+        shutdown_tracing()
+        shutdown_tracing()  # Multiple calls should be safe
+
+    @pytest.mark.unit
+    def test_init_tracing_without_endpoint(self):
+        """Test init_tracing without OTLP endpoint."""
+        from kubectl_mcp_tool.observability.tracing import (
+            init_tracing,
+            is_tracing_available,
+            shutdown_tracing,
+        )
+
+        shutdown_tracing()
+
+        if is_tracing_available():
+            # Clear any OTLP endpoint
+            with patch.dict("os.environ", {}, clear=True):
+                result = init_tracing(service_name="test-service")
+                assert result is True  # Should initialize with no exporter
+                shutdown_tracing()
+        else:
+            result = init_tracing()
+            assert result is False  # OpenTelemetry not available
+
+
+class TestObservabilityModule:
+    """Tests for observability module exports."""
+
+    @pytest.mark.unit
+    def test_module_imports(self):
+        """Test that all observability functions can be imported."""
+        from kubectl_mcp_tool.observability import (
+            StatsCollector,
+            get_stats_collector,
+            get_metrics,
+            record_tool_call_metric,
+            record_tool_error_metric,
+            record_tool_duration_metric,
+            is_prometheus_available,
+            init_tracing,
+            traced_tool_call,
+            get_tracer,
+            is_tracing_available,
+            shutdown_tracing,
+        )
+
+        assert StatsCollector is not None
+        assert get_stats_collector is not None
+        assert get_metrics is not None
+        assert init_tracing is not None
+        assert traced_tool_call is not None
+
+    @pytest.mark.unit
+    def test_stats_and_metrics_integration(self):
+        """Test stats and metrics work together."""
+        from kubectl_mcp_tool.observability import (
+            get_stats_collector,
+            record_tool_call_metric,
+            get_metrics,
+        )
+
+        collector = get_stats_collector()
+        collector.reset()
+
+        # Record calls in both stats and metrics
+        for i in range(5):
+            collector.record_tool_call("integration_tool", success=True, duration=0.1)
+            record_tool_call_metric("integration_tool", success=True, duration=0.1)
+
+        stats = collector.get_stats()
+        metrics = get_metrics()
+
+        assert stats["tool_calls_total"] == 5
+        assert isinstance(metrics, str)
+
+
+class TestSamplerConfiguration:
+    """Tests for OpenTelemetry sampler configuration."""
+
+    @pytest.mark.unit
+    def test_sampler_always_on(self):
+        """Test OTEL_TRACES_SAMPLER=always_on."""
+        from kubectl_mcp_tool.observability.tracing import is_tracing_available
+
+        if not is_tracing_available():
+            pytest.skip("OpenTelemetry not available")
+
+        from kubectl_mcp_tool.observability.tracing import _get_sampler
+
+        with patch.dict("os.environ", {"OTEL_TRACES_SAMPLER": "always_on"}):
+            sampler = _get_sampler()
+            assert sampler is not None
+
+    @pytest.mark.unit
+    def test_sampler_always_off(self):
+        """Test OTEL_TRACES_SAMPLER=always_off."""
+        from kubectl_mcp_tool.observability.tracing import is_tracing_available
+
+        if not is_tracing_available():
+            pytest.skip("OpenTelemetry not available")
+
+        from kubectl_mcp_tool.observability.tracing import _get_sampler
+
+        with patch.dict("os.environ", {"OTEL_TRACES_SAMPLER": "always_off"}):
+            sampler = _get_sampler()
+            assert sampler is not None
+
+    @pytest.mark.unit
+    def test_sampler_trace_id_ratio(self):
+        """Test OTEL_TRACES_SAMPLER=traceidratio."""
+        from kubectl_mcp_tool.observability.tracing import is_tracing_available
+
+        if not is_tracing_available():
+            pytest.skip("OpenTelemetry not available")
+
+        from kubectl_mcp_tool.observability.tracing import _get_sampler
+
+        with patch.dict("os.environ", {
+            "OTEL_TRACES_SAMPLER": "traceidratio",
+            "OTEL_TRACES_SAMPLER_ARG": "0.5"
+        }):
+            sampler = _get_sampler()
+            assert sampler is not None
+
+    @pytest.mark.unit
+    def test_sampler_invalid_ratio(self):
+        """Test invalid OTEL_TRACES_SAMPLER_ARG defaults to 1.0."""
+        from kubectl_mcp_tool.observability.tracing import is_tracing_available
+
+        if not is_tracing_available():
+            pytest.skip("OpenTelemetry not available")
+
+        from kubectl_mcp_tool.observability.tracing import _get_sampler
+
+        with patch.dict("os.environ", {
+            "OTEL_TRACES_SAMPLER": "traceidratio",
+            "OTEL_TRACES_SAMPLER_ARG": "invalid"
+        }):
+            # Should not raise, defaults to 1.0
+            sampler = _get_sampler()
+            assert sampler is not None
+
+
+class TestToolStatsDataclass:
+    """Tests for ToolStats dataclass."""
+
+    @pytest.mark.unit
+    def test_tool_stats_defaults(self):
+        """Test ToolStats default values."""
+        from kubectl_mcp_tool.observability.stats import ToolStats
+
+        stats = ToolStats()
+
+        assert stats.calls == 0
+        assert stats.errors == 0
+        assert stats.total_duration == 0.0
+        assert stats.last_call_time is None
+        assert stats.last_error_time is None
+
+    @pytest.mark.unit
+    def test_tool_stats_custom_values(self):
+        """Test ToolStats with custom values."""
+        from kubectl_mcp_tool.observability.stats import ToolStats
+
+        now = time.time()
+        stats = ToolStats(
+            calls=10,
+            errors=2,
+            total_duration=5.5,
+            last_call_time=now,
+            last_error_time=now - 100
+        )
+
+        assert stats.calls == 10
+        assert stats.errors == 2
+        assert stats.total_duration == 5.5
+        assert stats.last_call_time == now


### PR DESCRIPTION
## Summary

- Add OpenTelemetry tracing integration for distributed tracing
- Implement /stats endpoint for server statistics
- Implement /metrics endpoint for Prometheus metrics export
- Add metrics collection for tool calls and performance monitoring

## New Files

### kubectl_mcp_tool/observability/
- `__init__.py` - Module exports
- `tracing.py` - OpenTelemetry tracing integration
- `stats.py` - Server statistics and /stats endpoint
- `metrics.py` - Prometheus metrics and /metrics endpoint

### Tests
- `tests/test_observability.py` - Test suite for observability module

## Configuration

Environment variables:
- `OTEL_EXPORTER_OTLP_ENDPOINT` - OTLP exporter endpoint
- `OTEL_SERVICE_NAME` - Service name for tracing

## Test plan

- [ ] Unit tests pass
- [ ] Tracing spans appear in Jaeger/Zipkin
- [ ] Metrics exposed at /metrics endpoint
- [ ] Stats available at /stats endpoint