### PR TITLE
feat(ci): upload wheel files to GitHub releases

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -54,7 +54,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
 
     - name: Upload wheel to GitHub Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         files: |
           dist/*.whl

--- a/README.md
+++ b/README.md
@@ -159,7 +159,10 @@ pip install kubectl-mcp-server[ui]
 ### Install from GitHub Release
 
 ```bash
-# Install specific version directly from GitHub release
+# Install specific version directly from GitHub release (replace {VERSION} with desired version)
+pip install https://github.com/rohitg00/kubectl-mcp-server/releases/download/v{VERSION}/kubectl_mcp_server-{VERSION}-py3-none-any.whl
+
+# Example: Install v1.19.0
 pip install https://github.com/rohitg00/kubectl-mcp-server/releases/download/v1.19.0/kubectl_mcp_server-1.19.0-py3-none-any.whl
 
 # Or install latest from git


### PR DESCRIPTION
## Summary
- Uploads `.whl` and `.tar.gz` files to GitHub releases as assets
- Users can install directly from GitHub without PyPI

## Installation from GitHub Release
```bash
# Specific version
pip install https://github.com/rohitg00/kubectl-mcp-server/releases/download/v1.19.0/kubectl_mcp_server-1.19.0-py3-none-any.whl

# Latest from git
pip install git+https://github.com/rohitg00/kubectl-mcp-server.git
```

## Why not GitHub Packages?
GitHub Packages doesn't natively support PyPI format. This approach:
- Attaches wheel files to existing releases
- No additional registry configuration needed
- Works with standard pip install

## Test plan
- [ ] Merge and create a new release
- [ ] Verify wheel files appear as release assets
- [ ] Test install via release URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release artifacts are now automatically published to GitHub Releases, enabling direct installation of specific versions from release packages.

* **Documentation**
  * Added installation instructions for installing from GitHub releases or the latest development version from the Git repository.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->