### PR TITLE
fix(topology): fix kubectl describe and fetch all 16 resource types

### DIFF
--- a/kubectl-mcp-app/test/server.test.ts
+++ b/kubectl-mcp-app/test/server.test.ts
@@ -52,7 +52,7 @@ describe("Server", () => {
       expect(server).toBeDefined();
     });
 
-    it("should register all 8 UI tools", () => {
+    it("should register all 9 UI tools plus proxy", () => {
       const server = createServer();
       const mockServer = (McpServer as unknown as ReturnType<typeof vi.fn>).mock
         .results[0].value;
@@ -70,10 +70,11 @@ describe("Server", () => {
       expect(toolNames).toContain("k8s-cost");
       expect(toolNames).toContain("k8s-events");
       expect(toolNames).toContain("k8s-network");
+      expect(toolNames).toContain("k8s-3d-topology");
       expect(toolNames).toContain("k8s-proxy");
     });
 
-    it("should register all 8 UI resources", () => {
+    it("should register all 9 UI resources", () => {
       const server = createServer();
       const mockServer = (McpServer as unknown as ReturnType<typeof vi.fn>).mock
         .results[0].value;
@@ -91,6 +92,7 @@ describe("Server", () => {
       expect(resourceUris).toContain("ui://k8s/cost.html");
       expect(resourceUris).toContain("ui://k8s/events.html");
       expect(resourceUris).toContain("ui://k8s/network.html");
+      expect(resourceUris).toContain("ui://k8s/topology.html");
     });
   });
 


### PR DESCRIPTION
## Summary
- Fixed broken "kubectl describe" button in the 3D topology inspector — was calling nonexistent `describe_resource` tool with wrong param name; now correctly calls `kubectl_describe` with `name` parameter
- Added fetching for all 10 missing Kubernetes resource types (StatefulSet, DaemonSet, ConfigMap, Secret, PVC, HPA, Job/CronJob, Namespace, ResourceQuota, NetworkPolicy) so the 3D viewer renders all 18 distinct mesh shapes instead of only 6
- Updated server tests to validate the new `k8s-3d-topology` tool and `ui://k8s/topology.html` resource registration

## Test plan
- [x] All 27 existing tests pass (`npx vitest run`)
- [x] Full build succeeds (9 UI bundles + server + CLI)
- [ ] Verify kubectl describe button works when connected to a live cluster
- [ ] Verify new resource types (StatefulSet, DaemonSet, ConfigMap, etc.) appear as distinct 3D shapes in the topology view
- [ ] Verify mock/fallback data renders all 18 mesh types when no cluster is connected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Kubernetes resource support to include Jobs, CronJobs, StatefulSets, DaemonSets, ConfigMaps, Secrets, PersistentVolumeClaims, HorizontalPodAutoscalers, Namespaces, ResourceQuotas, and NetworkPolicies in cluster topology.
  * Added 3D topology visualization UI tool for Kubernetes clusters.

* **Bug Fixes**
  * Fixed resource description functionality with corrected API calls and payload structure.

* **Tests**
  * Updated test suite to reflect new UI tools and resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->