### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Talk to your clusters like you talk to a DevOps expert. Debug crashed pods, opti
 
 ---
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/rohitg00-kubectl-mcp-server).
+
 ## Installation
 
 ### Quick Start with npx (Recommended - Zero Install)


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/rohitg00-kubectl-mcp-server)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Hosted deployment" section to the README providing direct access to the hosted version of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->