### PR TITLE
fix: patch kubernetes-client auth_settings for bearer token key mismatch

### DIFF
--- a/kubectl_mcp_tool/k8s_config.py
+++ b/kubectl_mcp_tool/k8s_config.py
@@ -315,7 +315,50 @@ def patch_kubernetes_config():
         logger.debug("kubernetes package not available for patching")
 
 
+def _patch_kubernetes_auth_settings():
+    """Patch Configuration.auth_settings for kubernetes-client >= 30 compatibility.
+
+    In recent versions the kubeconfig loader stores the bearer token under
+    api_key['authorization'], but Configuration.auth_settings() only checks
+    api_key['BearerToken'].  The two are out of sync so the Authorization header
+    is never added to requests, producing a 401 despite a valid token in the
+    kubeconfig.  This patch makes auth_settings() fall back to the
+    'authorization' key when 'BearerToken' is absent.
+    """
+    try:
+        from kubernetes.client import Configuration
+
+        if getattr(Configuration, '_mcp_auth_patched', False):
+            return
+
+        _orig = Configuration.auth_settings
+
+        def _patched(self):
+            auth = _orig(self)
+            if 'BearerToken' not in auth and 'authorization' in self.api_key:
+                # Trigger the token-refresh hook the same way get_api_key_with_prefix
+                # would, so expiring tokens (OIDC, GCP) are refreshed before we read.
+                if self.refresh_api_key_hook is not None:
+                    self.refresh_api_key_hook(self)
+                token = self.api_key.get('authorization', '')
+                if token:
+                    auth['BearerToken'] = {
+                        'type': 'api_key',
+                        'in': 'header',
+                        'key': 'authorization',
+                        'value': token,
+                    }
+            return auth
+
+        Configuration.auth_settings = _patched
+        Configuration._mcp_auth_patched = True
+        logger.debug("Patched kubernetes.client.Configuration.auth_settings for token key compatibility")
+    except Exception as e:
+        logger.debug(f"Failed to patch kubernetes auth settings: {e}")
+
+
 patch_kubernetes_config()
+_patch_kubernetes_auth_settings()
 
 
 def _load_config_for_context(context: str = "") -> Any:


### PR DESCRIPTION
kubernetes-client >= 30 stores the bearer token under api_key['authorization'] in KubeConfigLoader._set_config(), but Configuration.auth_settings() only checks api_key['BearerToken']. This mismatch means the Authorization header is never sent, resulting in 401 errors even when the kubeconfig has a valid token.

Add _patch_kubernetes_auth_settings() which monkey-patches auth_settings() at class level to fall back to the 'authorization' key when 'BearerToken' is absent. The patch also calls refresh_api_key_hook before reading the token so that expiring OIDC/GCP credentials are refreshed correctly.

The patch is idempotent (guarded by _mcp_auth_patched) and applied at module load time alongside the existing patch_kubernetes_config() call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes client authentication compatibility with enhanced bearer token refresh handling to ensure more reliable cluster connections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/kubectl-mcp-server/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->